### PR TITLE
Fix GitHub spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# VSCode Github build status
+# VSCode GitHub build status
 
-A plugin that shows current build status fetched from Github (if available).
+A plugin that shows current build status fetched from GitHub (if available).
 
 ![Screenshot](images/screenshot.png)
 
 ## How it works
 
-When ".vsgitbuild" is available in the workspace, plugin looks for ".git" folder down to the root folder, starting from workspace directory. When found, it'll fetch repository information and use configuration in the file to fetch build status information from Github API every N seconds (and every time current commit changes - if you commit something, or if branch changes).
+When ".vsgitbuild" is available in the workspace, plugin looks for ".git" folder down to the root folder, starting from workspace directory. When found, it'll fetch repository information and use configuration in the file to fetch build status information from GitHub API every N seconds (and every time current commit changes - if you commit something, or if branch changes).
 
 ## Enabling
 
@@ -22,7 +22,7 @@ In order to enable the plugin, you need to have a ".vsgitbuild" file in your wor
 ```
 
 #### username
-Your Github username that'll be used to fetch the status
+Your GitHub username that'll be used to fetch the status
 
 #### password
 Either your password or auth token; it is **strongly** recommended to **not** use your password, but auth token - for details, see [here](https://blog.github.com/2013-05-16-personal-api-tokens/)

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "vscode-gitbuild",
     "version": "1.0.1",
-    "displayName": "Github Build Status",
-    "description": "Visual Studio Code Github build status plugin",
+    "displayName": "GitHub Build Status",
+    "description": "Visual Studio Code GitHub build status plugin",
     "main": "./build/src/extension",
     "scripts": {
         "compile": "tsc -watch -p ./",
@@ -35,7 +35,7 @@
         "commands": [
             {
                 "command": "githubbuild.listBuilds",
-                "title": "Github build: List all builds"
+                "title": "GitHub build: List all builds"
             }
         ]
     },


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.

It would be great if you could update it on Visual Studio Marketplace page as well: 

![image](https://user-images.githubusercontent.com/743291/64059935-89365a00-cb7a-11e9-9b88-18f82dcc85c2.png)
